### PR TITLE
Made easily runnable on Unix-like systems

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python3
 from detector import find
 
 url = input("Enter the url to check: ")


### PR DESCRIPTION
My old PR had quite a few things going on so I'm separating it into 3 PRs.

I have made it so that way users of Unix-like systems, the most popular being Linux and MacOS\*, can easily run it like any other program by simply typing `./main.py` rather than `python3 ./main.py` (it's worth noting that the `./...` is because `main.py` is a local file; the only way to remove, which is not a good idea for such a generically named file).

\*I'm only 100% sure that the changes I made will be useful for Linux users but from what I understand they will also benefit Mac users. Worst case scenario it won't make anything worse for them.

This is a standard thing to do for python projects as a quality of life thing

Changes made:

* Update file permissions with execute so that the user can execute it as a normal command rather than needing to.
* Added `#!/usr/bin/python3` at the beginning of the file. This comment will tell the system "Hey when you try to run this file, use `/usr/bin/python3`" which is important since by default it will run the file with Unix shell.

