### PR TITLE
Added .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc


### PR DESCRIPTION
I'm splitting my old PR into 3 separate PRs since it did enough things that it should probably be separate PRs.

This will make it so that git automatically ignores `__pycache__/` and `.pyc` files, I saw you accidentally committed `__pycache__/` and had to remove it with another commit, this will prevent that by automatically ignoring the `__pycache__/` folder.